### PR TITLE
Remove unnecessary assignment in AccessControl class

### DIFF
--- a/backend/utils/access_control.py
+++ b/backend/utils/access_control.py
@@ -30,7 +30,6 @@ class AccessControl:
 
         for module_name, module_value in management_modules.items():
             self_module = getattr(self, module_name)
-            self_module = {}
             path = management_path / module_name
             entries_glob = ".dm/*/meta.*.json"
             for one in path.glob(entries_glob):


### PR DESCRIPTION
Line 32 in access_control.py takes the AccessControl object's attributes. The removed line overwrote this assignment with a new dictionary, which means line 50 assigns the resource_obj to a local scope dictionary. Therefore, the subsequent create, store and delete function calls at line 55-57 do not see the loaded permissions as they reference the AccessControl object's attributes insted of the local scope dictionary.

This was a bug that I came across when I tried to run the backend/reload.sh script, but it did not load any permissions into Redis